### PR TITLE
added path.normalize to sourceRoot

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class Mjml {
      * @param {Object} options
      */
     register(entry = 'resources/mail', output = 'resource/views/mail', options = {}) {
-        options.sourceRoot = this.findSourceRoot(entry);
+        options.sourceRoot = path.normalize(this.findSourceRoot(entry));
 
         if (entry.includes('*')) {
             entry = glob.sync(entry);


### PR DESCRIPTION
There were errors on my windows system caused by the else branch in line 77-83. 
You want to replace the sourceRoot with the output relativePath, I guess it was not found. So all my files ended up in the entry folder and not in the specified output folder.
This plugin works fine on os/linux. 

Thank you for creating this plugin :)