### PR TITLE
Match Laravel folder structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class Mjml {
      * @param {String} output
      * @param {Object} options
      */
-    register(entry = 'resources/mail', output = 'resource/views/mail', options = {}) {
+    register(entry = 'resources/mail', output = 'resources/views/mail', options = {}) {
         options.sourceRoot = path.normalize(this.findSourceRoot(entry));
 
         if (entry.includes('*')) {


### PR DESCRIPTION
Typo on the default value of the `output` param